### PR TITLE
Adding missing required props to foreign and bbmd network port modes

### DIFF
--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -2867,6 +2867,7 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
                 apdu_len = BACNET_STATUS_ERROR;
                 break;
             }
+            break;
 #endif /* BBMD_ENABLED */
 #if (BBMD_CLIENT_ENABLED)
         case PROP_FD_BBMD_ADDRESS:

--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -2895,8 +2895,25 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
             }
             break;
         case PROP_FD_SUBSCRIPTION_LIFETIME:
-            apdu_len = encode_application_unsigned(&apdu[0],
-                Network_Port_Remote_BBMD_BIP6_Lifetime(rpdata->object_instance));
+            switch(network_type) {
+#if (defined(BACDL_ALL) || defined(BACDL_BIP))
+              case PORT_TYPE_BIP:
+                apdu_len = encode_application_unsigned(&apdu[0],
+                    Network_Port_Remote_BBMD_BIP_Lifetime(rpdata->object_instance));
+                break;
+#endif
+#if (defined(BACDL_ALL) || defined(BACDL_BIP6))
+              case PORT_TYPE_BIP6:
+                apdu_len = encode_application_unsigned(&apdu[0],
+                    Network_Port_Remote_BBMD_BIP6_Lifetime(rpdata->object_instance));
+                break;
+#endif
+              default:
+                rpdata->error_class = ERROR_CLASS_PROPERTY;
+                rpdata->error_code = ERROR_CODE_INVALID_ARRAY_INDEX;
+                apdu_len = BACNET_STATUS_ERROR;
+              break;
+            }
             break;
 #endif
 #endif

--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -2839,6 +2839,9 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
 #endif
 #if (defined(BACDL_ALL) || defined(BACDL_BIP6))
               case PORT_TYPE_BIP6:
+                apdu_len = bvlc6_broadcast_distribution_table_encode(&apdu[0],
+                    rpdata->application_data_len,
+                    Network_Port_BBMD_IP6_BD_Table(rpdata->object_instance));
                 break;
 #endif
               default:
@@ -2859,6 +2862,9 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
 #endif
 #if (defined(BACDL_ALL) || defined(BACDL_BIP6))
               case PORT_TYPE_BIP6:
+                apdu_len = bvlc6_foreign_device_table_encode(&apdu[0],
+                    rpdata->application_data_len,
+                    Network_Port_BBMD_IP6_FD_Table(rpdata->object_instance));
                 break;
 #endif
               default:

--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -1677,6 +1677,7 @@ bool Network_Port_Remote_BBMD_BIP_Lifetime_Set(
 }
 
 /* IPv6 BBMD related getters and setters */
+#if (defined(BACDL_ALL) || defined(BACDL_BIP6))
 
 /**
  * For a given object instance-number, returns the BBMD-Accept-FD-Registrations
@@ -2021,6 +2022,7 @@ bool Network_Port_Remote_BBMD_BIP6_Lifetime_Set(
 
     return status;
 }
+#endif
 
 /**
  * For a given object instance-number, gets the BACnet/IP UDP Port number
@@ -2663,6 +2665,10 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
         return 0;
     }
 
+#if (!BBMD_CLIENT_ENABLED)
+    (void) network_type;
+#endif
+
     if ((index = Network_Port_Instance_To_Index(rpdata->object_instance)) < BACNET_NETWORK_PORTS_MAX) {
       network_type = Object_List[index].Network_Type;
     }
@@ -3079,6 +3085,8 @@ bool Network_Port_Read_Range(
 {
     /* return value */
     bool status = false;
+
+    (void) pInfo;
 
     switch (pRequest->object_property) {
         /* required properties */

--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -2647,7 +2647,7 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
 #if (defined(BACDL_ALL) || defined(BACDL_BIP)) && (BBMD_ENABLED || BBMD_CLIENT_ENABLED)
     BACNET_IP_ADDRESS ip_address;
 #endif
-#if (defined(BACDL_ALL) || defined(BACDL_BIP)) && (BBMD_ENABLED || BBMD_CLIENT_ENABLED)
+#if (defined(BACDL_ALL) || defined(BACDL_BIP6)) && (BBMD_ENABLED || BBMD_CLIENT_ENABLED)
     BACNET_IP6_ADDRESS ip6_address;
 #endif
     uint8_t *apdu = NULL;

--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -2846,12 +2846,15 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
                   rpdata->object_instance, &ip_address);
               apdu_len = bvlc_foreign_device_bbmd_host_address_encode(
                   &apdu[0], apdu_size, &ip_address);
-            } else if(network_type == PORT_TYPE_BIP6) {
+            }
+#if (defined(BACDL_ALL) || defined(BACDL_BIP6))
+            else if(network_type == PORT_TYPE_BIP6) {
               Network_Port_Remote_BBMD_IP6_Address_And_Port(
                   rpdata->object_instance, &ip6_address);
               apdu_len = bvlc6_foreign_device_bbmd_host_address_encode(
                   &apdu[0], apdu_size, &ip6_address);
             }
+#endif
             break;
         case PROP_FD_SUBSCRIPTION_LIFETIME:
             apdu_len = encode_application_unsigned(&apdu[0],

--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -1566,6 +1566,8 @@ bool Network_Port_Remote_BBMD_IP_Address_Set(
             Object_List[index].Network.IPv4.BBMD_IP_Address[1] = b;
             Object_List[index].Network.IPv4.BBMD_IP_Address[2] = c;
             Object_List[index].Network.IPv4.BBMD_IP_Address[3] = d;
+
+            status = true;
         }
     }
 
@@ -1913,6 +1915,7 @@ bool Network_Port_Remote_BBMD_IP6_Address_Set(
     if (index < BACNET_NETWORK_PORTS_MAX) {
         if (Object_List[index].Network_Type == PORT_TYPE_BIP6) {
             memcpy(Object_List[index].Network.IPv6.BBMD_IP_Address, addr, IP6_ADDRESS_MAX);
+            status = true;
         }
     }
 

--- a/src/bacnet/basic/object/netport.h
+++ b/src/bacnet/basic/object/netport.h
@@ -289,6 +289,7 @@ extern "C" {
         uint32_t object_instance,
         uint16_t value);
 
+#if (defined(BACDL_ALL) || defined(BACDL_BIP6))
     BACNET_STACK_EXPORT
     bool Network_Port_BBMD_IP6_Accept_FD_Registrations(
         uint32_t object_instance);
@@ -332,6 +333,7 @@ extern "C" {
     bool Network_Port_Remote_BBMD_BIP6_Lifetime_Set(
         uint32_t object_instance,
         uint16_t value);
+#endif
 
     BACNET_STACK_EXPORT
     BACNET_IP_MODE Network_Port_BIP6_Mode(

--- a/src/bacnet/basic/object/netport.h
+++ b/src/bacnet/basic/object/netport.h
@@ -290,6 +290,50 @@ extern "C" {
         uint16_t value);
 
     BACNET_STACK_EXPORT
+    bool Network_Port_BBMD_IP6_Accept_FD_Registrations(
+        uint32_t object_instance);
+    BACNET_STACK_EXPORT
+    bool Network_Port_BBMD_IP6_Accept_FD_Registrations_Set(
+        uint32_t object_instance,
+        bool value);
+
+    BACNET_STACK_EXPORT
+    void *Network_Port_BBMD_IP6_BD_Table(uint32_t object_instance);
+    BACNET_STACK_EXPORT
+    bool Network_Port_BBMD_IP6_BD_Table_Set(
+        uint32_t object_instance,
+        void *bdt_head);
+    BACNET_STACK_EXPORT
+    void *Network_Port_BBMD_IP6_FD_Table(uint32_t object_instance);
+    BACNET_STACK_EXPORT
+    bool Network_Port_BBMD_IP6_FD_Table_Set(
+        uint32_t object_instance,
+        void *fdt_head);
+
+    BACNET_STACK_EXPORT
+    bool Network_Port_Remote_BBMD_IP6_Address(
+        uint32_t object_instance,
+        uint8_t *addr);
+    BACNET_STACK_EXPORT
+    bool Network_Port_Remote_BBMD_IP6_Address_Set(
+        uint32_t object_instance,
+        uint8_t *addr);
+    BACNET_STACK_EXPORT
+    uint16_t Network_Port_Remote_BBMD_BIP6_Port(
+        uint32_t object_instance);
+    BACNET_STACK_EXPORT
+    bool Network_Port_Remote_BBMD_BIP6_Port_Set(
+        uint32_t object_instance,
+        uint16_t value);
+    BACNET_STACK_EXPORT
+    uint16_t Network_Port_Remote_BBMD_BIP6_Lifetime(
+        uint32_t object_instance);
+    BACNET_STACK_EXPORT
+    bool Network_Port_Remote_BBMD_BIP6_Lifetime_Set(
+        uint32_t object_instance,
+        uint16_t value);
+
+    BACNET_STACK_EXPORT
     BACNET_IP_MODE Network_Port_BIP6_Mode(
         uint32_t object_instance);
     BACNET_STACK_EXPORT

--- a/src/bacnet/datalink/bvlc6.c
+++ b/src/bacnet/datalink/bvlc6.c
@@ -1467,6 +1467,8 @@ int bvlc6_decode_secure_bvll(uint8_t *pdu,
     int bytes_consumed = 0;
     uint16_t i = 0;
 
+    (void) sbuf_size;
+
     if (pdu && sbuf) {
         if (sbuf_len) {
             *sbuf_len = pdu_len;
@@ -1598,3 +1600,135 @@ int bvlc6_foreign_device_bbmd_host_address_encode(
 
     return apdu_len;
 }
+
+/**
+ * @brief Encode the Broadcast-Distribution-Table for Network Port object
+ *
+ *    BACnetLIST of BACnetBDTEntry
+ *
+ *    BACnetBDTEntry ::= SEQUENCE {
+ *       bbmd-address [0] BACnetHostNPort,
+ *           BACnetHostNPort ::= SEQUENCE {
+ *               host [0] BACnetHostAddress,
+ *                   BACnetHostAddress ::= CHOICE {
+ *                       ip-address [1] OCTET STRING, -- 4 octets for B/IP
+ *                   }
+ *               port [1] Unsigned16
+ *           }
+ *        broadcast-mask [1] OCTET STRING -- shall be present if BACnet/IP, and absent for BACnet/IPv6
+ *    }
+ *
+ * @param apdu - the APDU buffer
+ * @param apdu_size - the APDU buffer size
+ * @param bdt_head - head of the BDT linked list
+ * @return length of the APDU buffer
+ */
+int bvlc6_broadcast_distribution_table_encode(uint8_t *apdu,
+    uint16_t apdu_size,
+    BACNET_IP6_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_head)
+{
+    int len = 0;
+    int apdu_len = 0;
+    int entry_size = 0;
+    BACNET_OCTET_STRING octet_string;
+    BACNET_IP6_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry;
+
+    bdt_entry = bdt_head;
+    while (bdt_entry) {
+        if (bdt_entry->valid) {
+            /* bbmd-address [0] BACnetHostNPort - opening */
+            len = encode_opening_tag(&apdu[apdu_len], 0);
+            apdu_len += len;
+            /*  host [0] BACnetHostAddress - opening */
+            len = encode_opening_tag(&apdu[apdu_len], 0);
+            apdu_len += len;
+            /* CHOICE - ip-address [1] OCTET STRING */
+            octetstring_init(&octet_string, &bdt_entry->bip6_address.address[0],
+                IP6_ADDRESS_MAX);
+            len =
+                encode_context_octet_string(&apdu[apdu_len], 1, &octet_string);
+            apdu_len += len;
+            /*  host [0] BACnetHostAddress - closing */
+            len = encode_closing_tag(&apdu[apdu_len], 0);
+            apdu_len += len;
+            /* port [1] Unsigned16 */
+            len = encode_context_unsigned(
+                &apdu[apdu_len], 1, bdt_entry->bip6_address.port);
+            apdu_len += len;
+            /* bbmd-address [0] BACnetHostNPort - closing */
+            len = encode_closing_tag(&apdu[apdu_len], 0);
+            apdu_len += len;
+        }
+        if (!entry_size) {
+            entry_size = apdu_len;
+        }
+        /* next entry */
+        bdt_entry = bdt_entry->next;
+        if ((apdu_len + entry_size) > apdu_size) {
+            /* check for available space */
+            break;
+        }
+    }
+
+    return apdu_len;
+}
+
+/**
+ * @brief Encode the Foreign_Device-Table for Network Port object
+ *
+ *    BACnetLIST of BACnetFDTEntry
+ *
+ *    BACnetFDTEntry ::= SEQUENCE {
+ *        bacnetip-address [0] OCTET STRING, -- the 6-octet B/IP or 18-octet B/IPv6 address of the registrant
+ *        time-to-live [1] Unsigned16, -- time to live in seconds
+ *        remaining-time-to-live [2] Unsigned16 -- remaining time in seconds
+ *    }
+ *
+ * @param apdu - the APDU buffer
+ * @param apdu_size - the APDU buffer size
+ * @param fdt_head - head of the BDT linked list
+ * @return length of the APDU buffer
+ */
+int bvlc6_foreign_device_table_encode(uint8_t *apdu,
+    uint16_t apdu_size,
+    BACNET_IP6_FOREIGN_DEVICE_TABLE_ENTRY *fdt_head)
+{
+    int len = 0;
+    int apdu_len = 0;
+    int entry_size = 0;
+    BACNET_OCTET_STRING octet_string = { 0 };
+    BACNET_IP6_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry;
+
+    fdt_entry = fdt_head;
+    while (fdt_entry) {
+        if (fdt_entry->valid) {
+            /* bacnetip-address [0] OCTET STRING */
+            len = bvlc6_encode_address(octetstring_value(&octet_string),
+                octetstring_capacity(&octet_string), &fdt_entry->bip6_address);
+            octetstring_truncate(&octet_string, len);
+            len =
+                encode_context_octet_string(&apdu[apdu_len], 0, &octet_string);
+            apdu_len += len;
+            /* time-to-live [1] Unsigned16 */
+            len = encode_context_unsigned(
+                &apdu[apdu_len], 1, fdt_entry->ttl_seconds);
+            apdu_len += len;
+            /* remaining-time-to-live [2] Unsigned16 */
+            len = encode_context_unsigned(
+                &apdu[apdu_len], 2, fdt_entry->ttl_seconds_remaining);
+            apdu_len += len;
+        }
+        if (!entry_size) {
+            entry_size = apdu_len;
+        }
+        /* next entry */
+        fdt_entry = fdt_entry->next;
+        if ((apdu_len + entry_size) > apdu_size) {
+            /* check for available space */
+            break;
+        }
+    }
+
+    return apdu_len;
+}
+

--- a/src/bacnet/datalink/bvlc6.h
+++ b/src/bacnet/datalink/bvlc6.h
@@ -423,6 +423,14 @@ extern "C" {
     int bvlc6_foreign_device_bbmd_host_address_encode(uint8_t *apdu,
         uint16_t apdu_size,
         BACNET_IP6_ADDRESS *ip6_address);
+    BACNET_STACK_EXPORT
+    int bvlc6_broadcast_distribution_table_encode(uint8_t *apdu,
+        uint16_t apdu_size,
+        BACNET_IP6_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_head);
+    BACNET_STACK_EXPORT
+    int bvlc6_foreign_device_table_encode(uint8_t *apdu,
+        uint16_t apdu_size,
+        BACNET_IP6_FOREIGN_DEVICE_TABLE_ENTRY *fdt_head);
 
 
 #ifdef __cplusplus

--- a/src/bacnet/datalink/dlenv.c
+++ b/src/bacnet/datalink/dlenv.c
@@ -466,7 +466,7 @@ void dlenv_network_port_init(void)
  */
 void dlenv_maintenance_timer(uint16_t elapsed_seconds)
 {
-#if defined(BACDL_BIP) || defined(BACDL_BIP6)
+#if defined(BACDL_BIP) || defined(BACDL_BIP6) || defined(BACDL_ALL)
     if (BBMD_Timer_Seconds) {
         if (BBMD_Timer_Seconds <= elapsed_seconds) {
             BBMD_Timer_Seconds = 0;
@@ -481,6 +481,8 @@ void dlenv_maintenance_timer(uint16_t elapsed_seconds)
             BBMD_Timer_Seconds = (uint16_t)BBMD_TTL_Seconds;
         }
     }
+#else
+    (void) elapsed_seconds;
 #endif
 }
 


### PR DESCRIPTION
Adding missing properties from IPv6 'foreign' an `'bbmd'` modes of network port.