### PR TITLE
Implementing hook that allows for storing in non-volatile memory written properties

### DIFF
--- a/apps/piface/device.c
+++ b/apps/piface/device.c
@@ -67,14 +67,14 @@ static object_functions_t My_Object_Table[] = {
         Device_Read_Property_Local, Device_Write_Property_Local,
         Device_Property_Lists, DeviceGetRRInfo, NULL /* Iterator */,
         NULL /* Value_Lists */, NULL /* COV */, NULL /* COV Clear */,
-        NULL /* Intrinsic Reporting */ },
+        NULL /* Intrinsic Reporting */, NULL /* Write_Property_Storage */ },
 #if (BACNET_PROTOCOL_REVISION >= 17)
     { OBJECT_NETWORK_PORT, Network_Port_Init, Network_Port_Count,
         Network_Port_Index_To_Instance, Network_Port_Valid_Instance,
         Network_Port_Object_Name, Network_Port_Read_Property,
         Network_Port_Write_Property, Network_Port_Property_Lists,
         NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
-        NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */ },
+        NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */, NULL /* Write_Property_Storage */ },
 #endif
     { OBJECT_BINARY_INPUT, Binary_Input_Init, Binary_Input_Count,
         Binary_Input_Index_To_Instance, Binary_Input_Valid_Instance,
@@ -82,20 +82,20 @@ static object_functions_t My_Object_Table[] = {
         Binary_Input_Write_Property, Binary_Input_Property_Lists,
         NULL /* ReadRangeInfo */, NULL /* Iterator */,
         Binary_Input_Encode_Value_List, Binary_Input_Change_Of_Value,
-        Binary_Input_Change_Of_Value_Clear, NULL /* Intrinsic Reporting */ },
+        Binary_Input_Change_Of_Value_Clear, NULL /* Intrinsic Reporting */, NULL /* Write_Property_Storage */ },
     { OBJECT_BINARY_OUTPUT, Binary_Output_Init, Binary_Output_Count,
         Binary_Output_Index_To_Instance, Binary_Output_Valid_Instance,
         Binary_Output_Object_Name, Binary_Output_Read_Property,
         Binary_Output_Write_Property, Binary_Output_Property_Lists,
         NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
-        NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */ },
+        NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */, NULL /* Write_Property_Storage */ },
     { MAX_BACNET_OBJECT_TYPE, NULL /* Init */, NULL /* Count */,
         NULL /* Index_To_Instance */, NULL /* Valid_Instance */,
         NULL /* Object_Name */, NULL /* Read_Property */,
         NULL /* Write_Property */, NULL /* Property_Lists */,
         NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
         NULL /* COV */, NULL /* COV Clear */,
-        NULL /* Intrinsic Reporting */ }
+        NULL /* Intrinsic Reporting */, NULL /* Write_Property_Storage */ }
 };
 
 /** Glue function to let the Device object, when called by a handler,

--- a/src/bacnet/basic/object/client/device-client.c
+++ b/src/bacnet/basic/object/client/device-client.c
@@ -117,7 +117,7 @@ static object_functions_t Object_Table[] = {
         Device_Property_Lists, NULL /* ReadRangeInfo */, NULL /* Iterator */,
         NULL /* Value_Lists */, NULL /* COV */, NULL /* COV Clear */,
         NULL /* Intrinsic Reporting */,
-        NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+        NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
 #if (BACNET_PROTOCOL_REVISION >= 17)
     { OBJECT_NETWORK_PORT, Network_Port_Init, Network_Port_Count,
         Network_Port_Index_To_Instance, Network_Port_Valid_Instance,
@@ -125,7 +125,7 @@ static object_functions_t Object_Table[] = {
         Network_Port_Write_Property, Network_Port_Property_Lists,
         NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
         NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-        NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+        NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
 #endif
     { MAX_BACNET_OBJECT_TYPE, NULL /* Init */, NULL /* Count */,
         NULL /* Index_To_Instance */, NULL /* Valid_Instance */,
@@ -134,7 +134,7 @@ static object_functions_t Object_Table[] = {
         NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
         NULL /* COV */, NULL /* COV Clear */,
         NULL /* Intrinsic Reporting */,
-        NULL /* Add_List_Element */, NULL /* Remove_List_Element */ }
+        NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ }
 };
 
 /** Glue function to let the Device object, when called by a handler,

--- a/src/bacnet/basic/object/device.c
+++ b/src/bacnet/basic/object/device.c
@@ -79,6 +79,7 @@
 #include "bacnet/basic/object/color_object.h"
 #include "bacnet/basic/object/color_temperature.h"
 #endif
+#include <stdio.h>
 
 /* local forward (semi-private) and external prototypes */
 int Device_Read_Property_Local(BACNET_READ_PROPERTY_DATA *rpdata);
@@ -99,7 +100,7 @@ static object_functions_t My_Object_Table[] = {
         Device_Property_Lists, DeviceGetRRInfo, NULL /* Iterator */,
         NULL /* Value_Lists */, NULL /* COV */, NULL /* COV Clear */,
         NULL /* Intrinsic Reporting */, NULL /* Add_List_Element */,
-        NULL /* Remove_List_Element */ },
+        NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
 #if (BACNET_PROTOCOL_REVISION >= 17)
     { OBJECT_NETWORK_PORT, Network_Port_Init, Network_Port_Count,
         Network_Port_Index_To_Instance, Network_Port_Valid_Instance,
@@ -107,7 +108,7 @@ static object_functions_t My_Object_Table[] = {
         Network_Port_Write_Property, Network_Port_Property_Lists,
         NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
         NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-        NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+        NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
 #endif
      { OBJECT_ANALOG_INPUT, Analog_Input_Init, Analog_Input_Count,
          Analog_Input_Index_To_Instance, Analog_Input_Valid_Instance,
@@ -116,14 +117,14 @@ static object_functions_t My_Object_Table[] = {
          NULL /* ReadRangeInfo */, NULL /* Iterator */,
          Analog_Input_Encode_Value_List, Analog_Input_Change_Of_Value,
          Analog_Input_Change_Of_Value_Clear, Analog_Input_Intrinsic_Reporting,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_ANALOG_OUTPUT, Analog_Output_Init, Analog_Output_Count,
          Analog_Output_Index_To_Instance, Analog_Output_Valid_Instance,
          Analog_Output_Object_Name, Analog_Output_Read_Property,
          Analog_Output_Write_Property, Analog_Output_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
     { OBJECT_ANALOG_VALUE, Analog_Value_Init, Analog_Value_Count,
         Analog_Value_Index_To_Instance, Analog_Value_Valid_Instance,
         Analog_Value_Object_Name, Analog_Value_Read_Property,
@@ -131,7 +132,7 @@ static object_functions_t My_Object_Table[] = {
         NULL /* ReadRangeInfo */, NULL /* Iterator */,
         Analog_Value_Encode_Value_List, Analog_Value_Change_Of_Value,
         Analog_Value_Change_Of_Value_Clear, Analog_Value_Intrinsic_Reporting,
-        NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+        NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_BINARY_INPUT, Binary_Input_Init, Binary_Input_Count,
          Binary_Input_Index_To_Instance, Binary_Input_Valid_Instance,
          Binary_Input_Object_Name, Binary_Input_Read_Property,
@@ -139,21 +140,21 @@ static object_functions_t My_Object_Table[] = {
          NULL /* ReadRangeInfo */, NULL /* Iterator */,
          Binary_Input_Encode_Value_List, Binary_Input_Change_Of_Value,
          Binary_Input_Change_Of_Value_Clear, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_BINARY_OUTPUT, Binary_Output_Init, Binary_Output_Count,
          Binary_Output_Index_To_Instance, Binary_Output_Valid_Instance,
          Binary_Output_Object_Name, Binary_Output_Read_Property,
          Binary_Output_Write_Property, Binary_Output_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_BINARY_VALUE, Binary_Value_Init, Binary_Value_Count,
          Binary_Value_Index_To_Instance, Binary_Value_Valid_Instance,
          Binary_Value_Object_Name, Binary_Value_Read_Property,
          Binary_Value_Write_Property, Binary_Value_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_CHARACTERSTRING_VALUE, CharacterString_Value_Init,
          CharacterString_Value_Count, CharacterString_Value_Index_To_Instance,
          CharacterString_Value_Valid_Instance, CharacterString_Value_Object_Name,
@@ -164,20 +165,20 @@ static object_functions_t My_Object_Table[] = {
          CharacterString_Value_Change_Of_Value,
          CharacterString_Value_Change_Of_Value_Clear,
          NULL /* Intrinsic Reporting */, NULL /* Add_List_Element */,
-         NULL /* Remove_List_Element */ },
+         NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_COMMAND, Command_Init, Command_Count, Command_Index_To_Instance,
          Command_Valid_Instance, Command_Object_Name, Command_Read_Property,
          Command_Write_Property, Command_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_INTEGER_VALUE, Integer_Value_Init, Integer_Value_Count,
          Integer_Value_Index_To_Instance, Integer_Value_Valid_Instance,
          Integer_Value_Object_Name, Integer_Value_Read_Property,
          Integer_Value_Write_Property, Integer_Value_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
 #if defined(INTRINSIC_REPORTING)
     { OBJECT_NOTIFICATION_CLASS, Notification_Class_Init,
         Notification_Class_Count, Notification_Class_Index_To_Instance,
@@ -187,7 +188,7 @@ static object_functions_t My_Object_Table[] = {
         NULL /* Iterator */, NULL /* Value_Lists */, NULL /* COV */,
         NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
         Notification_Class_Add_List_Element,
-        Notification_Class_Remove_List_Element },
+        Notification_Class_Remove_List_Element, NULL /* Write_Property_Storage */ },
 #endif
      { OBJECT_LIFE_SAFETY_POINT, Life_Safety_Point_Init, Life_Safety_Point_Count,
          Life_Safety_Point_Index_To_Instance, Life_Safety_Point_Valid_Instance,
@@ -195,21 +196,21 @@ static object_functions_t My_Object_Table[] = {
          Life_Safety_Point_Write_Property, Life_Safety_Point_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_LOAD_CONTROL, Load_Control_Init, Load_Control_Count,
          Load_Control_Index_To_Instance, Load_Control_Valid_Instance,
          Load_Control_Object_Name, Load_Control_Read_Property,
          Load_Control_Write_Property, Load_Control_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_MULTI_STATE_INPUT, Multistate_Input_Init, Multistate_Input_Count,
          Multistate_Input_Index_To_Instance, Multistate_Input_Valid_Instance,
          Multistate_Input_Object_Name, Multistate_Input_Read_Property,
          Multistate_Input_Write_Property, Multistate_Input_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_MULTI_STATE_OUTPUT, Multistate_Output_Init,
          Multistate_Output_Count, Multistate_Output_Index_To_Instance,
          Multistate_Output_Valid_Instance, Multistate_Output_Object_Name,
@@ -217,7 +218,7 @@ static object_functions_t My_Object_Table[] = {
          Multistate_Output_Property_Lists, NULL /* ReadRangeInfo */,
          NULL /* Iterator */, NULL /* Value_Lists */, NULL /* COV */,
          NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_MULTI_STATE_VALUE, Multistate_Value_Init, Multistate_Value_Count,
          Multistate_Value_Index_To_Instance, Multistate_Value_Valid_Instance,
          Multistate_Value_Object_Name, Multistate_Value_Read_Property,
@@ -225,14 +226,14 @@ static object_functions_t My_Object_Table[] = {
          NULL /* ReadRangeInfo */, NULL /* Iterator */,
          Multistate_Value_Encode_Value_List, Multistate_Value_Change_Of_Value,
          Multistate_Value_Change_Of_Value_Clear, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_TRENDLOG, Trend_Log_Init, Trend_Log_Count,
          Trend_Log_Index_To_Instance, Trend_Log_Valid_Instance,
          Trend_Log_Object_Name, Trend_Log_Read_Property,
          Trend_Log_Write_Property, Trend_Log_Property_Lists, TrendLogGetRRInfo,
          NULL /* Iterator */, NULL /* Value_Lists */, NULL /* COV */,
          NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
  #if (BACNET_PROTOCOL_REVISION >= 14)
      { OBJECT_LIGHTING_OUTPUT, Lighting_Output_Init, Lighting_Output_Count,
          Lighting_Output_Index_To_Instance, Lighting_Output_Valid_Instance,
@@ -240,13 +241,13 @@ static object_functions_t My_Object_Table[] = {
          Lighting_Output_Write_Property, Lighting_Output_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_CHANNEL, Channel_Init, Channel_Count, Channel_Index_To_Instance,
          Channel_Valid_Instance, Channel_Object_Name, Channel_Read_Property,
          Channel_Write_Property, Channel_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
  #endif
  #if (BACNET_PROTOCOL_REVISION >= 24)
      { OBJECT_COLOR, Color_Init, Color_Count, Color_Index_To_Instance,
@@ -254,14 +255,14 @@ static object_functions_t My_Object_Table[] = {
          Color_Write_Property, Color_Property_Lists, NULL /* ReadRangeInfo */,
          NULL /* Iterator */, NULL /* Value_Lists */, NULL /* COV */,
          NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_COLOR_TEMPERATURE, Color_Temperature_Init, Color_Temperature_Count,
          Color_Temperature_Index_To_Instance, Color_Temperature_Valid_Instance,
          Color_Temperature_Object_Name, Color_Temperature_Read_Property,
          Color_Temperature_Write_Property, Color_Temperature_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
  #endif
  #if defined(BACFILE)
      { OBJECT_FILE, bacfile_init, bacfile_count, bacfile_index_to_instance,
@@ -269,7 +270,7 @@ static object_functions_t My_Object_Table[] = {
          bacfile_write_property, BACfile_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
  #endif
      { OBJECT_OCTETSTRING_VALUE, OctetString_Value_Init, OctetString_Value_Count,
          OctetString_Value_Index_To_Instance, OctetString_Value_Valid_Instance,
@@ -277,7 +278,7 @@ static object_functions_t My_Object_Table[] = {
          OctetString_Value_Write_Property, OctetString_Value_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_POSITIVE_INTEGER_VALUE, PositiveInteger_Value_Init,
          PositiveInteger_Value_Count, PositiveInteger_Value_Index_To_Instance,
          PositiveInteger_Value_Valid_Instance, PositiveInteger_Value_Object_Name,
@@ -286,21 +287,21 @@ static object_functions_t My_Object_Table[] = {
          PositiveInteger_Value_Property_Lists, NULL /* ReadRangeInfo */,
          NULL /* Iterator */, NULL /* Value_Lists */, NULL /* COV */,
          NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_SCHEDULE, Schedule_Init, Schedule_Count,
          Schedule_Index_To_Instance, Schedule_Valid_Instance,
          Schedule_Object_Name, Schedule_Read_Property, Schedule_Write_Property,
          Schedule_Property_Lists, NULL /* ReadRangeInfo */, NULL /* Iterator */,
          NULL /* Value_Lists */, NULL /* COV */, NULL /* COV Clear */,
          NULL /* Intrinsic Reporting */, NULL /* Add_List_Element */,
-         NULL /* Remove_List_Element */ },
+         NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
      { OBJECT_ACCUMULATOR, Accumulator_Init, Accumulator_Count,
          Accumulator_Index_To_Instance, Accumulator_Valid_Instance,
          Accumulator_Object_Name, Accumulator_Read_Property,
          Accumulator_Write_Property, Accumulator_Property_Lists,
          NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
          NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-         NULL /* Add_List_Element */, NULL /* Remove_List_Element */ },
+         NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ },
 #endif
     { MAX_BACNET_OBJECT_TYPE, NULL /* Init */, NULL /* Count */,
         NULL /* Index_To_Instance */, NULL /* Valid_Instance */,
@@ -308,7 +309,7 @@ static object_functions_t My_Object_Table[] = {
         NULL /* Write_Property */, NULL /* Property_Lists */,
         NULL /* ReadRangeInfo */, NULL /* Iterator */, NULL /* Value_Lists */,
         NULL /* COV */, NULL /* COV Clear */, NULL /* Intrinsic Reporting */,
-        NULL /* Add_List_Element */, NULL /* Remove_List_Element */ }
+        NULL /* Add_List_Element */, NULL /* Remove_List_Element */, NULL /* Write_Property_Storage */ }
 };
 
 /** Glue function to let the Device object, when called by a handler,
@@ -1733,7 +1734,12 @@ bool Device_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
                 } else
 #endif
                 {
-                    status = pObject->Object_Write_Property(wp_data);
+                  if(status = pObject->Object_Write_Property(wp_data)) {
+                    /* Call persistent storage hook if specified for the object */
+                    if(pObject->Object_Write_Property_Storage) {
+                      (void) pObject->Object_Write_Property_Storage(wp_data);
+                    }
+                  }
                 }
             } else {
                 wp_data->error_class = ERROR_CLASS_PROPERTY;

--- a/src/bacnet/basic/object/device.h
+++ b/src/bacnet/basic/object/device.h
@@ -168,6 +168,7 @@ typedef struct object_functions {
     object_intrinsic_reporting_function Object_Intrinsic_Reporting;
     list_element_function Object_Add_List_Element;
     list_element_function Object_Remove_List_Element;
+    write_property_storage_function Object_Write_Property_Storage;
 } object_functions_t;
 
 /* String Lengths - excluding any nul terminator */

--- a/src/bacnet/wp.h
+++ b/src/bacnet/wp.h
@@ -62,6 +62,20 @@ typedef bool(
     *write_property_function) (
     BACNET_WRITE_PROPERTY_DATA * wp_data);
 
+/** Attempts to store a new value to one property for this object type
+ *  of a given instance in a persistent storage. When specified for an object type, it is being invoked
+ *  after successful call to write_property_function handler.
+ * A function  implementation is the system specific and subject to the application requirements.
+ * @ingroup ObjHelpers
+ *
+ * @param wp_data [in] Pointer to the BACnet_Write_Property_Data structure,
+ *                     which is packed with the information from the WP request.
+ * @return 0 on success, error code on failure.
+ */
+typedef int(
+    *write_property_storage_function) (
+    BACNET_WRITE_PROPERTY_DATA * wp_data);
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */


### PR DESCRIPTION
The actual storage handle is to be written in the BACnet application and is purely optional. By the ASHRAE 135-2020 certain properties must be realitevely permanent i.e. clause "12.21.8: Recipient_List
This property, of type BACnetLIST of BACnetDestination, shall convey a list of zero or more recipient destinations to which
notifications shall be sent when event-initiating objects using this class detect the occurrence of an event. These recipient
destinations are intended to be relatively permanent, do not expire, and shall be maintained through a power failure or device
"restart." The destinations themselves define a structure of parameters that is summarized in Table 12-25."