### PR TITLE
Get/Set functions to support properties relative permanence requirement

### DIFF
--- a/src/bacnet/basic/object/nc.c
+++ b/src/bacnet/basic/object/nc.c
@@ -492,7 +492,7 @@ bool Notification_Class_Get_Recipient_List(
   uint32_t object_index = Notification_Class_Instance_To_Index(Object_Instance);
 
   if (object_index < MAX_NOTIFICATION_CLASSES) {
-    NOTIFICATION_CLASS_INFO *CurrentNotify = CurrentNotify = &NC_Info[object_index];
+    NOTIFICATION_CLASS_INFO *CurrentNotify = &NC_Info[object_index];
     int i;
 
     for (i = 0; i < NC_MAX_RECIPIENTS; i++)

--- a/src/bacnet/basic/object/nc.c
+++ b/src/bacnet/basic/object/nc.c
@@ -489,13 +489,10 @@ void Notification_Class_Get_Priorities(
 bool Notification_Class_Get_Recipient_List(
     uint32_t Object_Instance, BACNET_DESTINATION *pRecipientList)
 {
-  NOTIFICATION_CLASS_INFO *CurrentNotify;
-  uint32_t object_index;
-
-  object_index = Notification_Class_Instance_To_Index(Object_Instance);
+  uint32_t object_index = Notification_Class_Instance_To_Index(Object_Instance);
 
   if (object_index < MAX_NOTIFICATION_CLASSES) {
-    CurrentNotify = &NC_Info[object_index];
+    NOTIFICATION_CLASS_INFO *CurrentNotify = CurrentNotify = &NC_Info[object_index];
     int i;
 
     for (i = 0; i < NC_MAX_RECIPIENTS; i++)
@@ -510,13 +507,10 @@ bool Notification_Class_Get_Recipient_List(
 bool Notification_Class_Set_Recipient_List(
     uint32_t Object_Instance, BACNET_DESTINATION *pRecipientList)
 {
-  NOTIFICATION_CLASS_INFO *CurrentNotify;
-  uint32_t object_index;
-
-  object_index = Notification_Class_Instance_To_Index(Object_Instance);
+  uint32_t object_index = Notification_Class_Instance_To_Index(Object_Instance);
 
   if (object_index < MAX_NOTIFICATION_CLASSES) {
-    CurrentNotify = &NC_Info[object_index];
+    NOTIFICATION_CLASS_INFO *CurrentNotify = &NC_Info[object_index];
     int i;
 
     for (i = 0; i < NC_MAX_RECIPIENTS; i++)
@@ -546,17 +540,15 @@ void Notification_Class_Set_Priorities(
 void Notification_Class_Get_Ack_Required(
     uint32_t Object_Instance, uint8_t *pAckRequired)
 {
-    NOTIFICATION_CLASS_INFO *CurrentNotify;
     uint32_t object_index = Notification_Class_Instance_To_Index(Object_Instance);
 
     if (object_index < MAX_NOTIFICATION_CLASSES) {
-        CurrentNotify = &NC_Info[object_index];
+      NOTIFICATION_CLASS_INFO *CurrentNotify = &NC_Info[object_index];
+      *pAckRequired = CurrentNotify->Ack_Required;
     } else {
         *pAckRequired = 0;
         return; /* unknown object */
     }
-
-    *pAckRequired = CurrentNotify->Ack_Required;
 }
 
 void Notification_Class_Set_Ack_Required(

--- a/src/bacnet/basic/object/nc.c
+++ b/src/bacnet/basic/object/nc.c
@@ -486,6 +486,91 @@ void Notification_Class_Get_Priorities(
         pPriorityArray[i] = CurrentNotify->Priority[i];
 }
 
+bool Notification_Class_Get_Recipient_List(
+    uint32_t Object_Instance, BACNET_DESTINATION *pRecipientList)
+{
+  NOTIFICATION_CLASS_INFO *CurrentNotify;
+  uint32_t object_index;
+
+  object_index = Notification_Class_Instance_To_Index(Object_Instance);
+
+  if (object_index < MAX_NOTIFICATION_CLASSES) {
+    CurrentNotify = &NC_Info[object_index];
+    int i;
+
+    for (i = 0; i < NC_MAX_RECIPIENTS; i++)
+      pRecipientList[i] = CurrentNotify->Recipient_List[i];
+  } else {
+    return false; /* unknown object */
+  }
+
+  return true;
+}
+
+bool Notification_Class_Set_Recipient_List(
+    uint32_t Object_Instance, BACNET_DESTINATION *pRecipientList)
+{
+  NOTIFICATION_CLASS_INFO *CurrentNotify;
+  uint32_t object_index;
+
+  object_index = Notification_Class_Instance_To_Index(Object_Instance);
+
+  if (object_index < MAX_NOTIFICATION_CLASSES) {
+    CurrentNotify = &NC_Info[object_index];
+    int i;
+
+    for (i = 0; i < NC_MAX_RECIPIENTS; i++)
+      CurrentNotify->Recipient_List[i] = pRecipientList[i];
+  } else {
+    return false; /* unknown object */
+  }
+
+  return true;
+}
+
+void Notification_Class_Set_Priorities(
+    uint32_t Object_Instance, uint32_t *pPriorityArray)
+{
+  uint32_t object_index = Notification_Class_Instance_To_Index(Object_Instance);
+
+  if (object_index < MAX_NOTIFICATION_CLASSES) {
+    NOTIFICATION_CLASS_INFO *CurrentNotify = &NC_Info[object_index];
+    int i;
+
+    for (i = 0; i < 3; i++)
+      if (pPriorityArray[i] <= 255)
+        CurrentNotify->Priority[i] = pPriorityArray[i];
+  }
+}
+
+void Notification_Class_Get_Ack_Required(
+    uint32_t Object_Instance, uint8_t *pAckRequired)
+{
+    NOTIFICATION_CLASS_INFO *CurrentNotify;
+    uint32_t object_index = Notification_Class_Instance_To_Index(Object_Instance);
+
+    if (object_index < MAX_NOTIFICATION_CLASSES) {
+        CurrentNotify = &NC_Info[object_index];
+    } else {
+        *pAckRequired = 0;
+        return; /* unknown object */
+    }
+
+    *pAckRequired = CurrentNotify->Ack_Required;
+}
+
+void Notification_Class_Set_Ack_Required(
+    uint32_t Object_Instance, uint8_t Ack_Required)
+{
+    uint32_t object_index = Notification_Class_Instance_To_Index(Object_Instance);
+
+    if (object_index < MAX_NOTIFICATION_CLASSES) {
+        NOTIFICATION_CLASS_INFO *CurrentNotify = &NC_Info[object_index];
+        CurrentNotify->Ack_Required = Ack_Required;
+    }
+}
+
+
 static bool IsRecipientActive(
     BACNET_DESTINATION *pBacDest, uint8_t EventToState)
 {
@@ -526,12 +611,14 @@ static bool IsRecipientActive(
         return false;
     }
     /* valid FromTime */
-    if (datetime_compare_time(&DateTime.time, &pBacDest->FromTime) < 0)
+    if (datetime_compare_time(&DateTime.time, &pBacDest->FromTime) < 0) {
         return false;
+    }
 
     /* valid ToTime */
-    if (datetime_compare_time(&pBacDest->ToTime, &DateTime.time) < 0)
+    if (datetime_compare_time(&pBacDest->ToTime, &DateTime.time) < 0) {
         return false;
+    }
 
     return true;
 }

--- a/src/bacnet/basic/object/nc.h
+++ b/src/bacnet/basic/object/nc.h
@@ -103,6 +103,26 @@ void Notification_Class_Get_Priorities(
     uint32_t Object_Instance, uint32_t *pPriorityArray);
 
 BACNET_STACK_EXPORT
+void Notification_Class_Set_Priorities(
+    uint32_t Object_Instance, uint32_t *pPriorityArray);
+
+BACNET_STACK_EXPORT
+void Notification_Class_Get_Ack_Required(
+    uint32_t Object_Instance, uint8_t *pAckRequired);
+
+BACNET_STACK_EXPORT
+void Notification_Class_Set_Ack_Required(
+    uint32_t Object_Instance, uint8_t Ack_Required);
+
+BACNET_STACK_EXPORT
+bool Notification_Class_Get_Recipient_List(
+    uint32_t Object_Instance, BACNET_DESTINATION *pRecipientList);
+
+BACNET_STACK_EXPORT
+bool Notification_Class_Set_Recipient_List(
+    uint32_t Object_Instance, BACNET_DESTINATION *pRecipientList);
+
+BACNET_STACK_EXPORT
 void Notification_Class_common_reporting_function(
     BACNET_EVENT_NOTIFICATION_DATA *event_data);
 


### PR DESCRIPTION
These are to support the Write_Property_Storage call-back from `#38`  .