### PR TITLE
Implementing clauses c) and f) of 13.3.6 (out_of_range) algorithm

### DIFF
--- a/src/bacnet/basic/object/ai.c
+++ b/src/bacnet/basic/object/ai.c
@@ -1359,13 +1359,18 @@ void Analog_Input_Intrinsic_Reporting(uint32_t object_instance)
                    the HighLimitEnable flag must be set in the Limit_Enable
                    property, and (c) the TO-NORMAL flag must be set in the
                    Event_Enable property. */
-                if ((PresentVal <
-                        CurrentAI->High_Limit - CurrentAI->Deadband) &&
-                    ((CurrentAI->Limit_Enable & EVENT_HIGH_LIMIT_ENABLE) ==
-                        EVENT_HIGH_LIMIT_ENABLE) &&
-                    ((CurrentAI->Event_Enable & EVENT_ENABLE_TO_NORMAL) ==
-                        EVENT_ENABLE_TO_NORMAL)) {
-                    if (!CurrentAI->Remaining_Time_Delay)
+                if (
+                     ((PresentVal <
+                         CurrentAI->High_Limit - CurrentAI->Deadband) &&
+                      ((CurrentAI->Limit_Enable & EVENT_HIGH_LIMIT_ENABLE) ==
+                          EVENT_HIGH_LIMIT_ENABLE) &&
+                      ((CurrentAI->Event_Enable & EVENT_ENABLE_TO_NORMAL) ==
+                          EVENT_ENABLE_TO_NORMAL)) ||
+                      /* 13.3.6 (c) If pCurrentState is HIGH_LIMIT, and the HighLimitEnable flag of pLimitEnable is FALSE,
+                       * then indicate a transition to the NORMAL event state. */
+                      (!(CurrentAI->Limit_Enable & EVENT_HIGH_LIMIT_ENABLE))
+                   ) {
+                    if ((!CurrentAI->Remaining_Time_Delay) || (!(CurrentAI->Limit_Enable & EVENT_HIGH_LIMIT_ENABLE)))
                         CurrentAI->Event_State = EVENT_STATE_NORMAL;
                     else
                         CurrentAI->Remaining_Time_Delay--;
@@ -1384,12 +1389,17 @@ void Analog_Input_Intrinsic_Reporting(uint32_t object_instance)
                    set in the Limit_Enable property, and
                    (c) the TO-NORMAL flag must be set in the Event_Enable
                    property. */
-                if ((PresentVal > CurrentAI->Low_Limit + CurrentAI->Deadband) &&
+                if (
+                    ((PresentVal > CurrentAI->Low_Limit + CurrentAI->Deadband) &&
                     ((CurrentAI->Limit_Enable & EVENT_LOW_LIMIT_ENABLE) ==
                         EVENT_LOW_LIMIT_ENABLE) &&
                     ((CurrentAI->Event_Enable & EVENT_ENABLE_TO_NORMAL) ==
-                        EVENT_ENABLE_TO_NORMAL)) {
-                    if (!CurrentAI->Remaining_Time_Delay)
+                        EVENT_ENABLE_TO_NORMAL)) ||
+                    /* 13.3.6 (f) If pCurrentState is LOW_LIMIT, and the LowLimitEnable flag of pLimitEnable is FALSE,
+                     * then indicate a transition to the NORMAL event state. */
+                    (!(CurrentAI->Limit_Enable & EVENT_LOW_LIMIT_ENABLE))
+                   ) {
+                    if ( (!CurrentAI->Remaining_Time_Delay) || (!(CurrentAI->Limit_Enable & EVENT_LOW_LIMIT_ENABLE)) )
                         CurrentAI->Event_State = EVENT_STATE_NORMAL;
                     else
                         CurrentAI->Remaining_Time_Delay--;

--- a/src/bacnet/basic/object/av.c
+++ b/src/bacnet/basic/object/av.c
@@ -1157,13 +1157,18 @@ void Analog_Value_Intrinsic_Reporting(uint32_t object_instance)
                    the HighLimitEnable flag must be set in the Limit_Enable
                    property, and (c) the TO-NORMAL flag must be set in the
                    Event_Enable property. */
-                if ((PresentVal <
-                        CurrentAV->High_Limit - CurrentAV->Deadband) &&
-                    ((CurrentAV->Limit_Enable & EVENT_HIGH_LIMIT_ENABLE) ==
-                        EVENT_HIGH_LIMIT_ENABLE) &&
-                    ((CurrentAV->Event_Enable & EVENT_ENABLE_TO_NORMAL) ==
-                        EVENT_ENABLE_TO_NORMAL)) {
-                    if (!CurrentAV->Remaining_Time_Delay)
+                if (
+                     ((PresentVal <
+                         CurrentAV->High_Limit - CurrentAV->Deadband) &&
+                      ((CurrentAV->Limit_Enable & EVENT_HIGH_LIMIT_ENABLE) ==
+                          EVENT_HIGH_LIMIT_ENABLE) &&
+                      ((CurrentAV->Event_Enable & EVENT_ENABLE_TO_NORMAL) ==
+                          EVENT_ENABLE_TO_NORMAL)) ||
+                      /* 13.3.6 (c) If pCurrentState is HIGH_LIMIT, and the HighLimitEnable flag of pLimitEnable is FALSE,
+                       * then indicate a transition to the NORMAL event state. */
+                      (!(CurrentAV->Limit_Enable & EVENT_HIGH_LIMIT_ENABLE))
+                   ) {
+                    if ((!CurrentAV->Remaining_Time_Delay) || (!(CurrentAV->Limit_Enable & EVENT_HIGH_LIMIT_ENABLE)))
                         CurrentAV->Event_State = EVENT_STATE_NORMAL;
                     else
                         CurrentAV->Remaining_Time_Delay--;
@@ -1183,12 +1188,17 @@ void Analog_Value_Intrinsic_Reporting(uint32_t object_instance)
                    set in the Limit_Enable property, and
                    (c) the TO-NORMAL flag must be set in the Event_Enable
                    property. */
-                if ((PresentVal > CurrentAV->Low_Limit + CurrentAV->Deadband) &&
+                if (
+                    ((PresentVal > CurrentAV->Low_Limit + CurrentAV->Deadband) &&
                     ((CurrentAV->Limit_Enable & EVENT_LOW_LIMIT_ENABLE) ==
                         EVENT_LOW_LIMIT_ENABLE) &&
                     ((CurrentAV->Event_Enable & EVENT_ENABLE_TO_NORMAL) ==
-                        EVENT_ENABLE_TO_NORMAL)) {
-                    if (!CurrentAV->Remaining_Time_Delay)
+                        EVENT_ENABLE_TO_NORMAL)) ||
+                    /* 13.3.6 (f) If pCurrentState is LOW_LIMIT, and the LowLimitEnable flag of pLimitEnable is FALSE,
+                     * then indicate a transition to the NORMAL event state. */
+                    (!(CurrentAV->Limit_Enable & EVENT_LOW_LIMIT_ENABLE))
+                   ) {
+                    if ( (!CurrentAV->Remaining_Time_Delay) || (!(CurrentAV->Limit_Enable & EVENT_LOW_LIMIT_ENABLE)) )
                         CurrentAV->Event_State = EVENT_STATE_NORMAL;
                     else
                         CurrentAV->Remaining_Time_Delay--;


### PR DESCRIPTION
(c) If pCurrentState is HIGH_LIMIT, and the HighLimitEnable flag of pLimitEnable is FALSE, then indicate a transition
to the NORMAL event state.

(f) If pCurrentState is LOW_LIMIT, and the LowLimitEnable flag of pLimitEnable is FALSE, then indicate a transition
to the NORMAL event state.