### PR TITLE
Dc blt defects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 project(
   bacnet-stack
-  VERSION 1.4.0.9
+  VERSION 1.4.0.10
   LANGUAGES C)
 
 message(STATUS "Minimal optimization, debug info included")

--- a/src/bacnet/basic/object/av.c
+++ b/src/bacnet/basic/object/av.c
@@ -987,7 +987,7 @@ bool Analog_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
             } else {
                 status = false;
                 wp_data->error_class = ERROR_CLASS_PROPERTY;
-                wp_data->error_code = ERROR_CODE_VALUE_OUT_OF_RANGE;
+                wp_data->error_code = ERROR_CODE_INVALID_DATA_TYPE;
             }
             break;
         case PROP_OUT_OF_SERVICE:

--- a/src/bacnet/basic/object/msv.c
+++ b/src/bacnet/basic/object/msv.c
@@ -855,7 +855,7 @@ bool Multistate_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
     int len = 0;
     BACNET_APPLICATION_DATA_VALUE value;
 
-    fprintf(stderr, "Multistate_Value_Write_Property");
+    fprintf(stderr, "Multistate_Value_Write_Property\n");
     /* decode the some of the request */
     len = bacapp_decode_application_data(
         wp_data->application_data, wp_data->application_data_len, &value);
@@ -906,7 +906,7 @@ bool Multistate_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
                 wp_data->error_class = ERROR_CLASS_PROPERTY;
                 wp_data->error_code = ERROR_CODE_WRITE_ACCESS_DENIED;
             } else {
-                fprintf(stderr, "MSV ERROR");
+                fprintf(stderr, "MSV ERROR\n");
                 wp_data->error_class = ERROR_CLASS_PROPERTY;
                 wp_data->error_code = ERROR_CODE_UNKNOWN_PROPERTY;
             }

--- a/src/bacnet/basic/object/msv.c
+++ b/src/bacnet/basic/object/msv.c
@@ -855,6 +855,7 @@ bool Multistate_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
     int len = 0;
     BACNET_APPLICATION_DATA_VALUE value;
 
+    fprintf(stderr, "Multistate_Value_Write_Property");
     /* decode the some of the request */
     len = bacapp_decode_application_data(
         wp_data->application_data, wp_data->application_data_len, &value);
@@ -905,6 +906,7 @@ bool Multistate_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
                 wp_data->error_class = ERROR_CLASS_PROPERTY;
                 wp_data->error_code = ERROR_CODE_WRITE_ACCESS_DENIED;
             } else {
+                fprintf(stderr, "MSV ERROR");
                 wp_data->error_class = ERROR_CLASS_PROPERTY;
                 wp_data->error_code = ERROR_CODE_UNKNOWN_PROPERTY;
             }

--- a/src/bacnet/basic/object/msv.c
+++ b/src/bacnet/basic/object/msv.c
@@ -416,7 +416,7 @@ static bool Multistate_Value_Present_Value_Write(
                         Present_Value property are decoupled from the
                         physical point when the value of Out_Of_Service
                         is true. */
-                    if (value > count) {
+                    if (value > count || value == 0) {
                         *error_class = ERROR_CLASS_PROPERTY;
                         *error_code = ERROR_CODE_VALUE_OUT_OF_RANGE;
                         status = false;
@@ -855,7 +855,6 @@ bool Multistate_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
     int len = 0;
     BACNET_APPLICATION_DATA_VALUE value;
 
-    fprintf(stderr, "Multistate_Value_Write_Property\n");
     /* decode the some of the request */
     len = bacapp_decode_application_data(
         wp_data->application_data, wp_data->application_data_len, &value);
@@ -906,7 +905,6 @@ bool Multistate_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
                 wp_data->error_class = ERROR_CLASS_PROPERTY;
                 wp_data->error_code = ERROR_CODE_WRITE_ACCESS_DENIED;
             } else {
-                fprintf(stderr, "MSV ERROR\n");
                 wp_data->error_class = ERROR_CLASS_PROPERTY;
                 wp_data->error_code = ERROR_CODE_UNKNOWN_PROPERTY;
             }

--- a/src/bacnet/basic/service/h_wpm.c
+++ b/src/bacnet/basic/service/h_wpm.c
@@ -78,15 +78,6 @@ static int write_property_multiple_decode(
                             (long)wp_data->array_index);
                         if (device_write_property) {
                             if (device_write_property(wp_data) == false) {
-                                /* Workaround BTL Specified Test 9.23.2.X5 */
-                                if ((wp_data->error_class ==
-                                     ERROR_CLASS_PROPERTY) &&
-                                    (wp_data->error_code ==
-                                     ERROR_CODE_INVALID_DATA_TYPE)) {
-                                    wp_data->error_class = ERROR_CLASS_SERVICES;
-                                    wp_data->error_code =
-                                        ERROR_CODE_INVALID_TAG;
-                                }
                                 return BACNET_STATUS_ERROR;
                             }
                         }

--- a/src/bacnet/basic/service/h_wpm.c
+++ b/src/bacnet/basic/service/h_wpm.c
@@ -85,7 +85,7 @@ static int write_property_multiple_decode(
                                      ERROR_CODE_INVALID_DATA_TYPE)) {
                                     wp_data->error_class = ERROR_CLASS_SERVICES;
                                     wp_data->error_code =
-                                        ERROR_CODE_INVALID_ARRAY_INDEX;
+                                        ERROR_CODE_INVALID_TAG;
                                 }
                                 return BACNET_STATUS_ERROR;
                             }

--- a/src/bacnet/version.h
+++ b/src/bacnet/version.h
@@ -15,7 +15,7 @@
 #define BACNET_VERSION(x, y, z) (((x) << 16) + ((y) << 8) + (z))
 #endif
 
-#define BACNET_VERSION_TEXT "1.4.0.9"
+#define BACNET_VERSION_TEXT "1.4.0.10"
 #define BACNET_VERSION_CODE BACNET_VERSION(1, 4, 0)
 #define BACNET_VERSION_MAJOR ((BACNET_VERSION_CODE >> 16) & 0xFF)
 #define BACNET_VERSION_MINOR ((BACNET_VERSION_CODE >> 8) & 0xFF)

--- a/src/bacnet/wp.c
+++ b/src/bacnet/wp.c
@@ -315,7 +315,7 @@ bool write_property_type_valid(
         valid = false;
         if (wp_data) {
             wp_data->error_class = ERROR_CLASS_PROPERTY;
-            wp_data->error_code = ERROR_CODE_INVALID_ARRAY_INDEX;
+            wp_data->error_code = ERROR_CODE_INVALID_DATA_TYPE;
         }
     }
 


### PR DESCRIPTION
to address objects sending the correct error message when being sent the wrong datatype also a fix for MSV writability error.

JIRA's:
https://jira.se.com/browse/FIRMWARE-29273
https://jira.se.com/browse/FIRMWARE-29045 