### PR TITLE
Implementation of Forwarded-Address-Resulution handler

### DIFF
--- a/src/bacnet/basic/bbmd6/h_bbmd6.c
+++ b/src/bacnet/basic/bbmd6/h_bbmd6.c
@@ -626,7 +626,9 @@ static void bbmd6_forwarded_address_resolution_handler(
     uint32_t vmac_src = 0;
     uint32_t vmac_target = 0;
     uint32_t vmac_me = 0;
-    BACNET_IP6_ADDRESS bip6_address = { 0, };
+    BACNET_IP6_ADDRESS bip6_address = {
+        0,
+    };
 
     if (addr && pdu) {
         PRINTF("BIP6: Received Forwarded-Address-Resolution.\n");
@@ -642,7 +644,8 @@ static void bbmd6_forwarded_address_resolution_handler(
                     /* The Address-Resolution-ACK message is unicast
                        to the B/IPv6 node that originally initiated
                        the Address-Resolution message. */
-                    bvlc6_send_address_resolution_ack(&bip6_address, vmac_me, vmac_src);
+                    bvlc6_send_address_resolution_ack(
+                        &bip6_address, vmac_me, vmac_src);
                 }
             }
         }

--- a/src/bacnet/basic/bbmd6/h_bbmd6.c
+++ b/src/bacnet/basic/bbmd6/h_bbmd6.c
@@ -17,7 +17,7 @@
 #include "bacnet/basic/bbmd6/vmac.h"
 #include "bacnet/basic/bbmd6/h_bbmd6.h"
 
-static bool BVLC6_Debug;
+static bool BVLC6_Debug = false;
 #if PRINT_ENABLED
 #include <stdarg.h>
 #include <stdio.h>
@@ -613,6 +613,43 @@ static void bbmd6_address_resolution_handler(
 }
 
 /**
+ * Handler for Forwarded-Address-Resolution
+ *
+ * @param addr - BACnet/IPv6 source address any NAK or reply back to.
+ * @param pdu - The received NPDU+APDU buffer.
+ * @param pdu_len - How many bytes in NPDU+APDU buffer.
+ */
+static void bbmd6_forwarded_address_resolution_handler(
+    const BACNET_IP6_ADDRESS *addr, const uint8_t *pdu, uint16_t pdu_len)
+{
+    int function_len = 0;
+    uint32_t vmac_src = 0;
+    uint32_t vmac_target = 0;
+    uint32_t vmac_me = 0;
+    BACNET_IP6_ADDRESS bip6_address = { 0, };
+
+    if (addr && pdu) {
+        PRINTF("BIP6: Received Forwarded-Address-Resolution.\n");
+        if (bbmd6_address_match_self(addr)) {
+            /* ignore messages from my IPv6 address */
+        } else {
+            function_len = bvlc6_decode_forwarded_address_resolution(
+                pdu, pdu_len, &vmac_src, &vmac_target, &bip6_address);
+            if (function_len) {
+                bbmd6_add_vmac(vmac_src, addr);
+                vmac_me = Device_Object_Instance_Number();
+                if (vmac_target == vmac_me) {
+                    /* The Address-Resolution-ACK message is unicast
+                       to the B/IPv6 node that originally initiated
+                       the Address-Resolution message. */
+                    bvlc6_send_address_resolution_ack(&bip6_address, vmac_me, vmac_src);
+                }
+            }
+        }
+    }
+}
+
+/**
  * Handler for Address-Resolution-ACK
  *
  * @param addr - BACnet/IPv6 source address any NAK or reply back to.
@@ -789,8 +826,7 @@ int bvlc6_bbmd_disabled_handler(
                 }
                 break;
             case BVLC6_FORWARDED_ADDRESS_RESOLUTION:
-                result_code = BVLC6_RESULT_ADDRESS_RESOLUTION_NAK;
-                send_result = true;
+                bbmd6_forwarded_address_resolution_handler(addr, pdu, pdu_len);
                 break;
             case BVLC6_ADDRESS_RESOLUTION:
                 bbmd6_address_resolution_handler(addr, pdu, pdu_len);


### PR DESCRIPTION
Addressing the following BTL test cases:

**12.4.3.1.3 Execute Forwarded-Address-Resolution**
Purpose: To verify that an IUT, operating as a foreign device, will process a Forwarded-Address-Resolution message.
Test Concept: The TD, acting as a BBMD, sends a Forwarded-Address-Resolution message to the IUT on behalf of device
D2. It is verified that the IUT responds to D2 with an Address-Resolution message.
Test Steps:
1. TRANSMIT DA = IUT, SA = TD,
Forwarded-Address-Resolution,
Original-Source-Virtual-Address = D2,
Target-Virtual-Address = IUT
Original-Source-B/IPv6-Address = D2
2. RECEIVE
DA = D2, SA = IUT
Address-Resolution-ACK,
Source-Virtual-Address = IUT,
Destination-Virtual-Address = D2
3. CHECK (The IUT does not issue any Forwarded-Address-Resolution BVLCs)

**12.4.2.1.5 Execute Forwarded-Address-Resolution**
Purpose: To verify that an IUT, operating in normal IPv6 mode, will process a Forwarded-Address-Resolution message.
Test Concept: The TD, acting as a BBMD, sends a Forwarded-Address-Resolution message to the IUT on behalf of device
D2. It is verified that the IUT responds to D2 with an Address-Resolution message.
1. TRANSMIT DA = IUT, SA = TD,
Forwarded-Address-Resolution,
Original-Source-Virtual-Address = D2,
Target-Virtual-Address = IUT
Original-Source-B/IPv6-Address = D2
2. RECEIVE DA = D2, SA = IUT
Address-Resolution-ACK,
Source-Virtual-Address = IUT,
Destination-Virtual-Address = D2
3. CHECK (The IUT does not issue any Forwarded-Address-Resolution BVLCs)

