### PR TITLE
The PROP_TIME_STAMPS correct parsing to have eventual WRITE_ACCESS_DENIED instead of VALUE_OUT_OF_RANGE error code

### DIFF
--- a/src/bacnet/basic/object/ai.c
+++ b/src/bacnet/basic/object/ai.c
@@ -1241,13 +1241,22 @@ bool Analog_Input_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
         return false;
     }
     /* decode the some of the request */
+#if defined(BACAPP_COMPLEX_TYPES)
+    len = bacapp_decode_known_property(
+        wp_data->application_data, wp_data->application_data_len, &value,
+        wp_data->object_type, wp_data->object_property);
+#else
     len = bacapp_decode_application_data(
         wp_data->application_data, wp_data->application_data_len, &value);
+#endif
     /* FIXME: len < application_data_len: more data? */
     if (len < 0) {
         /* error while decoding - a value larger than we can handle */
         wp_data->error_class = ERROR_CLASS_PROPERTY;
         wp_data->error_code = ERROR_CODE_VALUE_OUT_OF_RANGE;
+        fprintf(stderr, "+++++ [%s %d %s] tukej\r\n",
+                __FILE__, __LINE__, __func__
+               );
         return false;
     }
     /*  only array properties can have array options */

--- a/src/bacnet/basic/object/ai.c
+++ b/src/bacnet/basic/object/ai.c
@@ -1254,9 +1254,6 @@ bool Analog_Input_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
         /* error while decoding - a value larger than we can handle */
         wp_data->error_class = ERROR_CLASS_PROPERTY;
         wp_data->error_code = ERROR_CODE_VALUE_OUT_OF_RANGE;
-        fprintf(stderr, "+++++ [%s %d %s] tukej\r\n",
-                __FILE__, __LINE__, __func__
-               );
         return false;
     }
     /*  only array properties can have array options */

--- a/src/bacnet/basic/object/av.c
+++ b/src/bacnet/basic/object/av.c
@@ -927,8 +927,14 @@ bool Analog_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
         return false;
     }
     /* decode the some of the request */
+#if defined(BACAPP_COMPLEX_TYPES)
+    len = bacapp_decode_known_property(
+        wp_data->application_data, wp_data->application_data_len, &value,
+        wp_data->object_type, wp_data->object_property);
+#else
     len = bacapp_decode_application_data(
         wp_data->application_data, wp_data->application_data_len, &value);
+#endif
     /* FIXME: len < application_data_len: more data? */
     if (len < 0) {
         /* error while decoding - a value larger than we can handle */

--- a/src/bacnet/basic/object/bi.c
+++ b/src/bacnet/basic/object/bi.c
@@ -1090,8 +1090,14 @@ bool Binary_Input_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
     struct object_data *pObject;
 
     /* decode the some of the request */
+#if defined(BACAPP_COMPLEX_TYPES)
+    len = bacapp_decode_known_property(
+        wp_data->application_data, wp_data->application_data_len, &value,
+        wp_data->object_type, wp_data->object_property);
+#else
     len = bacapp_decode_application_data(
         wp_data->application_data, wp_data->application_data_len, &value);
+#endif
     /* FIXME: len < application_data_len: more data? */
     if (len < 0) {
         /* error while decoding - a value larger than we can handle */

--- a/src/bacnet/basic/object/bv.c
+++ b/src/bacnet/basic/object/bv.c
@@ -1106,8 +1106,14 @@ bool Binary_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
     }
 
     /* Decode the some of the request. */
+#if defined(BACAPP_COMPLEX_TYPES)
+    len = bacapp_decode_known_property(
+        wp_data->application_data, wp_data->application_data_len, &value,
+        wp_data->object_type, wp_data->object_property);
+#else
     len = bacapp_decode_application_data(
         wp_data->application_data, wp_data->application_data_len, &value);
+#endif
     /* FIXME: len < application_data_len: more data? */
     if (len < 0) {
         /* error while decoding - a value larger than we can handle */


### PR DESCRIPTION
Addressing the following issue reported by the BTL:
'1.After transmitting WriteProperty-Request to the properties that are marked as Read-only in the EPICS,
IUT should respond BACnet-Error-PDU with,
Error Class = PROPERTY,
Error Code = WRITE_ACCESS_DENIED

'1.IUT responded BACnet-Error-PDU with,
'Error Class' = PROPERTY,
'Error Code’ = VALUE_OUT_OF_RANGE

