### PR TITLE
Looks like the notification must be sent unconditionally at subscription as well as re-subscription

### DIFF
--- a/src/bacnet/basic/service/h_cov.c
+++ b/src/bacnet/basic/service/h_cov.c
@@ -381,13 +381,6 @@ static bool cov_list_subscribe(
                     COV_Subscriptions[index].dest_index = MAX_COV_ADDRESSES;
                     cov_address_remove_unused();
                 } else {
-                    const BACNET_OBJECT_TYPE object_type =
-                        (BACNET_OBJECT_TYPE)COV_Subscriptions[index]
-                            .monitoredObjectIdentifier.type;
-                    const uint32_t object_instance =
-                        COV_Subscriptions[index]
-                            .monitoredObjectIdentifier.instance;
-
                     COV_Subscriptions[index].dest_index = cov_address_add(src);
                     COV_Subscriptions[index].flag.issueConfirmedNotifications =
                         cov_data->issueConfirmedNotifications;

--- a/src/bacnet/basic/service/h_cov.c
+++ b/src/bacnet/basic/service/h_cov.c
@@ -392,9 +392,8 @@ static bool cov_list_subscribe(
                     COV_Subscriptions[index].flag.issueConfirmedNotifications =
                         cov_data->issueConfirmedNotifications;
                     COV_Subscriptions[index].lifetime = cov_data->lifetime;
-                    if (Device_COV(object_type, object_instance)) {
-                        cov_change_detected_notify();
-                    }
+                    COV_Subscriptions[index].flag.send_requested = true;
+                    cov_change_detected_notify();
                 }
                 if (COV_Subscriptions[index].invokeID) {
                     tsm_free_invoke_id(COV_Subscriptions[index].invokeID);
@@ -431,11 +430,8 @@ static bool cov_list_subscribe(
                 cov_data->issueConfirmedNotifications;
             COV_Subscriptions[index].invokeID = 0;
             COV_Subscriptions[index].lifetime = cov_data->lifetime;
-            if (Device_COV(
-                    cov_data->monitoredObjectIdentifier.type,
-                    cov_data->monitoredObjectIdentifier.instance)) {
-                cov_change_detected_notify();
-            }
+            COV_Subscriptions[index].flag.send_requested = true;
+            cov_change_detected_notify();
         }
     } else if (!existing_entry) {
         if (first_invalid_index < 0) {


### PR DESCRIPTION
The Conformance to the pt 3 of test case 8.2.1:

Test Steps:
REPEAT X = (one supported object of each type) DO {
1. TRANSMIT SubscribeCOV-Request,
'Subscriber Process Identifier' = (any value > 0 chosen by the TD),
Copyrighted material licensed to Darshan M on 2024-09-20 for licensee's use only.
All rights reserved. No further reproduction or distribution is permitted. Distributed by Techstreet for ASHRAE, www.techstreet.com
8. APPLICATION SERVICE INITIATION TESTS
ANSI/ASHRAE Standard 135.1-2023
355
'Monitored Object Identifier' = X,
'Issue Confirmed Notifications' = TRUE,
'Lifetime' = L
2. RECEIVE BACnet-SimpleACK-PDU
3. BEFORE Notification Fail Time
RECEIVE ConfirmedCOVNotification-Request,
'Subscriber Process Identifier' = (the same value used in step 1),
'Initiating Device Identifier' = IUT,
'Monitored Object Identifier' = X,
'Time Remaining' = (any value appropriate for the Lifetime selected),
'List of Values' = (the initial Present_Value and initial Status_Flags)
4. TRANSMIT BACnet-SimpleACK-PDU
....