### PR TITLE
Blt object name dc

### DIFF
--- a/src/bacnet/basic/object/device.c
+++ b/src/bacnet/basic/object/device.c
@@ -1975,8 +1975,6 @@ static bool Device_Write_Property_Object_Name(
     } else if (len == 0) {
         wp_data->error_class = ERROR_CLASS_PROPERTY;
         wp_data->error_code = ERROR_CODE_WRITE_ACCESS_DENIED;
-        fprintf(stderr, " [%s %d] Invalid Object Name data type.\n",
-            __FILE__, __LINE__);
     } else {
         wp_data->error_class = ERROR_CLASS_PROPERTY;
         wp_data->error_code = ERROR_CODE_VALUE_OUT_OF_RANGE;
@@ -1995,9 +1993,6 @@ static bool Device_Write_Property_Object_Name(
                 status = false;
             }
         } else {
-            fprintf(stderr, " [%s %d] before writing the object name, "
-                "we need to set the object name in the device.\n",
-                __FILE__, __LINE__);
             status = Object_Write_Property(wp_data);
         }
     }

--- a/src/bacnet/basic/object/device.c
+++ b/src/bacnet/basic/object/device.c
@@ -1976,7 +1976,7 @@ static bool Device_Write_Property_Object_Name(
         wp_data->error_class = ERROR_CLASS_PROPERTY;
         wp_data->error_code = ERROR_CODE_WRITE_ACCESS_DENIED;
         fprintf(stderr, " [%s %d] Invalid Object Name data type.\n",
-            __FILE_, __LINE__);
+            __FILE__, __LINE__);
     } else {
         wp_data->error_class = ERROR_CLASS_PROPERTY;
         wp_data->error_code = ERROR_CODE_VALUE_OUT_OF_RANGE;

--- a/src/bacnet/basic/object/device.c
+++ b/src/bacnet/basic/object/device.c
@@ -1974,7 +1974,9 @@ static bool Device_Write_Property_Object_Name(
         }
     } else if (len == 0) {
         wp_data->error_class = ERROR_CLASS_PROPERTY;
-        wp_data->error_code = ERROR_CODE_INVALID_DATA_TYPE;
+        wp_data->error_code = ERROR_CODE_WRITE_ACCESS_DENIED;
+        fprintf(stderr, " [%s %d] Invalid Object Name data type.\n",
+            __FILE_, __LINE__);
     } else {
         wp_data->error_class = ERROR_CLASS_PROPERTY;
         wp_data->error_code = ERROR_CODE_VALUE_OUT_OF_RANGE;
@@ -1984,12 +1986,8 @@ static bool Device_Write_Property_Object_Name(
         if (Device_Valid_Object_Name(&value, &object_type, &object_instance)) {
             if ((object_type == wp_data->object_type) &&
                 (object_instance == wp_data->object_instance)) {
-                /* writing the same name to same object gives a
-                 * write-access-denied */
-                wp_data->error_class = ERROR_CLASS_PROPERTY;
-                wp_data->error_code = ERROR_CODE_WRITE_ACCESS_DENIED;
-
-                status = false;
+                /* writing same name to same object */
+                status = true;
             } else {
                 /* name already exists in some object */
                 wp_data->error_class = ERROR_CLASS_PROPERTY;
@@ -1997,6 +1995,9 @@ static bool Device_Write_Property_Object_Name(
                 status = false;
             }
         } else {
+            fprintf(stderr, " [%s %d] before writing the object name, "
+                "we need to set the object name in the device.\n",
+                __FILE__, __LINE__);
             status = Object_Write_Property(wp_data);
         }
     }

--- a/src/bacnet/wp.c
+++ b/src/bacnet/wp.c
@@ -311,10 +311,13 @@ bool write_property_type_valid(
 {
     /* assume success */
     bool valid = true;
-
+    fprintf(stderr," [%s %d] expected_tag=%d, value->tag=%d\n",
+            __func__, __LINE__, expected_tag, value ? value->tag : -1);
     if (value && (value->tag != expected_tag)) {
         valid = false;
         if (wp_data) {
+            fprintf(stderr," [%s %d] expected_tag=%d, value->tag=%d\n",
+                    __func__, __LINE__, expected_tag, value->tag);
             wp_data->error_class = ERROR_CLASS_PROPERTY;
             wp_data->error_code = ERROR_CODE_INVALID_DATA_TYPE;
         }

--- a/src/bacnet/wp.c
+++ b/src/bacnet/wp.c
@@ -311,13 +311,10 @@ bool write_property_type_valid(
 {
     /* assume success */
     bool valid = true;
-    fprintf(stderr," [%s %d] expected_tag=%d, value->tag=%d\n",
-            __func__, __LINE__, expected_tag, value ? value->tag : -1);
+
     if (value && (value->tag != expected_tag)) {
         valid = false;
         if (wp_data) {
-            fprintf(stderr," [%s %d] expected_tag=%d, value->tag=%d\n",
-                    __func__, __LINE__, expected_tag, value->tag);
             wp_data->error_class = ERROR_CLASS_PROPERTY;
             wp_data->error_code = ERROR_CODE_INVALID_DATA_TYPE;
         }


### PR DESCRIPTION
Addresses the issue for BLT for object-name a read-only property. It now sends a write-access-denied when a property value not associated with object-name is sent. 
JIRA: https://jira.se.com/browse/FIRMWARE-30039 
  