### PR TITLE
Changing to uint16_t to handle the extensions to BACnetEngineering uits as per clause 23.1 of ASHRAE 135-2020

### DIFF
--- a/src/bacnet/basic/object/ai.h
+++ b/src/bacnet/basic/object/ai.h
@@ -29,7 +29,7 @@ typedef struct analog_input_descr {
     float Present_Value_Backup;
     BACNET_RELIABILITY Reliability;
     bool Out_Of_Service;
-    uint8_t Units;
+    uint16_t Units;
     float Prior_Value;
     float COV_Increment;
     bool Changed;


### PR DESCRIPTION
…